### PR TITLE
Visual Studio compatibility fixes

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -56,19 +56,20 @@ if (libmodplug == "bundled") {
 
   config("libmodplug_private") {
     defines = [ "HAVE_CONFIG_H=1" ]
-    cflags = [
-      "-Wno-sizeof-pointer-memaccess",
-      "-Wno-deprecated-register",
-    ]
+    if (current_toolchain != "//build/lib/win:msvc") {
+      cflags = [
+        "-Wno-sizeof-pointer-memaccess",
+        "-Wno-deprecated-register",
+      ]
+      if (target_os == "win") {
+        cflags += [ "-Wno-macro-redefined" ]
+      }
+    }
     include_dirs = [
       "src/$target_os",
       "libmodplug-0.8.8.5/src",
       "libmodplug-0.8.8.5/src/libmodplug",
     ]
-
-    if (target_os == "win") {
-      cflags += [ "-Wno-macro-redefined" ]
-    }
   }
 } else {
   import("//build/lib/pkg_config.gni")

--- a/include/libmodplug/it_defs.h
+++ b/include/libmodplug/it_defs.h
@@ -1,1 +1,0 @@
-../../libmodplug-0.8.8.5/src/libmodplug/it_defs.h

--- a/include/libmodplug/it_defs.h
+++ b/include/libmodplug/it_defs.h
@@ -1,0 +1,1 @@
+#include "../../libmodplug-0.8.8.5/src/libmodplug/it_defs.h"

--- a/include/libmodplug/modplug.h
+++ b/include/libmodplug/modplug.h
@@ -1,1 +1,0 @@
-../../libmodplug-0.8.8.5/src/modplug.h

--- a/include/libmodplug/modplug.h
+++ b/include/libmodplug/modplug.h
@@ -1,0 +1,1 @@
+#include "../../libmodplug-0.8.8.5/src/modplug.h"

--- a/include/libmodplug/stdafx.h
+++ b/include/libmodplug/stdafx.h
@@ -1,0 +1,1 @@
+#include "../../libmodplug-0.8.8.5/src/libmodplug/stdafx.h"

--- a/include/libmodplug/stdafx.h
+++ b/include/libmodplug/stdafx.h
@@ -1,1 +1,0 @@
-../../libmodplug-0.8.8.5/src/libmodplug/stdafx.h

--- a/libmodplug-0.8.8.5/src/load_abc.cpp
+++ b/libmodplug-0.8.8.5/src/load_abc.cpp
@@ -2251,11 +2251,11 @@ static void abc_preprocess(ABCHANDLE *h, ABCMACRO *m)
 	if( m->n ) {
 		k = m->n - m->name;
 		for( i=0; i<14; i++ ) {
-			char t[strlen(m->name) + 1];
+			char *t = static_cast<char*>(alloca(strlen(m->name) + 1));
 			strcpy(t, m->name);
 			t[k] = "CDEFGABcdefgab"[i];
 			l = strlen(m->subst);
-			char s[2 * l + 1];
+			char *s = static_cast<char*>(alloca(2 * l + 1));
 			char *p = s;
 			for( j=0; j<l; j++ ) {
 				a = m->subst[j];

--- a/src/win/config.h
+++ b/src/win/config.h
@@ -29,19 +29,19 @@
 #define HAVE_STDLIB_H 1
 
 /* Define to 1 if you have the <strings.h> header file. */
-#define HAVE_STRINGS_H 1
+//#define HAVE_STRINGS_H 1
 
 /* Define to 1 if you have the <string.h> header file. */
 #define HAVE_STRING_H 1
 
 /* Define to 1 if you have the <sys/stat.h> header file. */
-#define HAVE_SYS_STAT_H 1
+//#define HAVE_SYS_STAT_H 1
 
 /* Define to 1 if you have the <sys/types.h> header file. */
-#define HAVE_SYS_TYPES_H 1
+//#define HAVE_SYS_TYPES_H 1
 
 /* Define to 1 if you have the <unistd.h> header file. */
-#define HAVE_UNISTD_H 1
+//#define HAVE_UNISTD_H 1
 
 /* Define to the sub-directory in which libtool stores uninstalled libraries.
    */


### PR DESCRIPTION
Fix up build config.
Replace symlinks with relative #includes.  (Symlinks require admin on Windows and Git for Windows doesn't check them out correctly anyway.)
Refactor dynamic sized arrays to use alloca instead.